### PR TITLE
v0.2.4: Logging levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ usage: python3 -m py-github-helper [-h] [-o ORGANIZATION] [-r REPOSITORY] [-t TO
 A python script that handles GitHub API calls.
 
 optional arguments:
-  -h, --help            show this help message and exit
+  -h, --help            show this help message and exit.
   -o ORGANIZATION, --organization ORGANIZATION
                         Owner of GitHub repository.
   -r REPOSITORY, --repository REPOSITORY
@@ -80,6 +80,10 @@ optional arguments:
                         Name of python function associated with API call being made.
   -e EXTRAS, --extras EXTRAS
                         Extra dictionary to allow for more arguments.
+  -v, --verbose 
+                        Log all INFO level messages to console.
+  -vv --debug, --very_verbose
+                        Log all DEBUG level messages to console.
 
 Expected Syntax:
         python3 -m py-github-helper -o <Organization Name> -r <Repository> -t <O-Auth Token> -u <Github username> -p <Github password> -l <PR Number> -c <Github API Command> -e '{"x": "sample", "y": 5, "z": "test}'

--- a/py_github_helper/__main__.py
+++ b/py_github_helper/__main__.py
@@ -1,8 +1,9 @@
 import logging
-from .utils.custom_arg_parser import parse_args
+from .utils.custom_arg_parser import parse_args, get_logging_level
 
 
 if __name__ == "__main__":
-    logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.ERROR)
-    print(parse_args())
+    log_level = get_logging_level()
+    logging.basicConfig(format="%(levelname)s: %(message)s", level=log_level)
+    logging.info(parse_args())
     exit(0)

--- a/py_github_helper/utils/commands.py
+++ b/py_github_helper/utils/commands.py
@@ -157,12 +157,10 @@ def add_comment(
     if "filename" in kwargs:
         with open(kwargs["filename"], "r") as file:
             message = f"{message}\n\n\n{file.read()}"
-    logging.info(
-        f"Adding comment for PR #{pull_request_id}...\n\tComment:\n\t'{message}' "
-    )
-    print(f"URL: {curr_endpoint}")
-    print(f"headers: {headers}")
-    print(f"body: {message}")
+    logging.info(f"Adding comment for PR #{pull_request_id}...\n\tComment:\n\t'{message}' ")
+    logging.debug(f"URL: {curr_endpoint}")
+    logging.debug(f"headers: {headers}")
+    logging.debug(f"body: {message}")
     response = requests.post(
         curr_endpoint, headers=headers, data=json.dumps({"body": message})
     )

--- a/py_github_helper/utils/custom_arg_parser.py
+++ b/py_github_helper/utils/custom_arg_parser.py
@@ -1,5 +1,17 @@
 from .commands import *
 
+def get_logging_level():
+    import argparse
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("-v", "--verbose")
+    parser.add_argument("-vv", "--debug", "--very_verbose")
+    args, _ = parser.parse_known_args()
+    if args.debug or args.very_verbose:
+        return logging.DEBUG
+    elif args.verbose:
+        return logging.INFO
+    else:
+        return logging.ERROR
 
 def parse_args():
     """
@@ -45,6 +57,12 @@ def parse_args():
     parser.add_argument(
         "-e", "--extras", type=str, help="Extra dictionary to allow for more arguments."
     )
+    parser.add_argument(
+        "-v", "--verbose", help="Enable verbose logging (INFO level). Default is ERROR level.",
+    )
+    parser.add_argument(
+        "-vv", "--debug", "--very_verbose", help="Enable verbose logging (DEBUG level). Default is ERROR level.",
+    )
 
     args = parser.parse_args()
     args = validate_args(args)
@@ -53,6 +71,8 @@ def parse_args():
     pretty_params = "\n".join(
         [f"{key:<20} {value}" for key, value in parameters.items()]
     )
+    log_level = get_logging_level()
+    logging.basicConfig(format="%(levelname)s: %(message)s", level=log_level)
     logging.info(f"\n\nParsed Parameters:\n{pretty_params}")
     logging.info("\n\n\n")
 


### PR DESCRIPTION
**Changes:**
1. Change `print()`s to `logging.debug()`
2. Adding `-v` and `-vv` flags
- optionally print `INFO` and `DEBUG` level logs 
- defaults to `ERROR` level logs

**Reasoning:**
`print()` statements include headers, which can contain secrets.
This package not print headers to console by default.